### PR TITLE
Delete: removes supportedSubmitMethods property

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,4 +22,3 @@ springdoc:
   swagger-ui:
     operationsSorter: alpha
     tagsSorter: alpha
-    supportedSubmitMethods: "get", "put", "post", "delete", "options", "head", "patch", "trace"


### PR DESCRIPTION
This property was throwing: org.yaml.snakeyaml.parser.ParserException: while parsing a block mapping